### PR TITLE
Remove redundant temperature sensor ID for CPU cores

### DIFF
--- a/vesnin.xml
+++ b/vesnin.xml
@@ -11185,7 +11185,7 @@
 		</property>
 		<property>
 			<id>IPMI_SENSOR_ID</id>
-			<value>0xA9</value>
+			<value></value>
 		</property>
 	</globalSetting>
 	<globalSetting>
@@ -11827,7 +11827,7 @@
 		</property>
 		<property>
 			<id>IPMI_SENSOR_ID</id>
-			<value>0xAE</value>
+			<value></value>
 		</property>
 	</globalSetting>
 	<globalSetting>
@@ -12521,7 +12521,7 @@
 		</property>
 		<property>
 			<id>IPMI_SENSOR_ID</id>
-			<value>0xAF</value>
+			<value></value>
 		</property>
 	</globalSetting>
 	<globalSetting>


### PR DESCRIPTION
Removed sensors:
CORE12, IPMI_SENSOR_ID 0xA9
CORE24, IPMI_SENSOR_ID 0xAE
CORE36, IPMI_SENSOR_ID 0xAF

Signed-off-by: Artem Senichev <a.senichev@yadro.com>